### PR TITLE
Fixes, for down arrow and contact section.

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -119,6 +119,11 @@ const ContactSocialAccounts = styled.div`
   align-items: center;
   margin-top: 7rem;
 
+  @supports (-ms-flow-from: thingy) {
+    /* Edge only */
+    justify-content: space-around;
+  }
+
   @media ${({ theme }) => theme.mediaQueries.smallest} {
     margin-top: 7.5rem;
   }

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -111,24 +111,24 @@ const smoothMovement = keyframes`
 const StyledArrow = styled(ChevronDown)`
   color: white;
   display: block;
-  min-height: 3rem;
-  min-width: 2rem;
+  height: 2rem;
+  width: 2rem;
   cursor: pointer;
   animation: ${smoothMovement} 1s infinite;
 
   @media ${({ theme }) => theme.mediaQueries.smallest} {
-    min-height: 4rem;
-    min-width: 3rem;
+    height: 4rem;
+    width: 3rem;
   }
 
   @media ${({ theme }) => theme.mediaQueries.medium} {
-    min-height: 5rem;
-    min-width: 4rem;
+    height: 5rem;
+    width: 4rem;
   }
 
   @media ${({ theme }) => theme.mediaQueries.largest} {
-    min-height: 3.5rem;
-    min-width: 2.5rem;
+    height: 3.5rem;
+    width: 2.5rem;
   }
 `;
 

--- a/src/templates/PortfolioProject.js
+++ b/src/templates/PortfolioProject.js
@@ -149,6 +149,11 @@ const ProjectLinkWrapper = styled.div`
   justify-content: space-evenly;
   margin: 2rem auto 0;
 
+  @supports (-ms-flow-from: thingy) {
+    /* Edge only */
+    justify-content: space-around;
+  }
+
   @media ${({ theme }) => theme.mediaQueries.smallest} {
     margin-top: 2rem;
     width: 75%;


### PR DESCRIPTION
Fixed down arrow in Hero section for non chromium browsers, fixed social accounts flexbox justify-content property with `@supports (-ms-flow-from: thingy) {
    /* Edge only */
    justify-content: space-around;
  }`
which applys to only edge browser space-around instead of space-evenly.